### PR TITLE
[reach_rs_driver] make python3 compatible

### DIFF
--- a/src/enway_reach_rs_driver/reach_rs_driver.py
+++ b/src/enway_reach_rs_driver/reach_rs_driver.py
@@ -124,7 +124,7 @@ class ReachRsDriver(object):
                 return
             except socket.timeout:
                 self.connection_status = 'connect timeout'
-            except socket.error,  msg:
+            except socket.error as msg:
                 self.connection_status = 'connect error ({0})'.format(msg)
             
         exit()


### PR DESCRIPTION
This PR adapts the script `reach_rs_driver.py` so that it is both compatible with python2 and 3 (this is needed for the move to noetic)